### PR TITLE
Enhance the detection of touch.

### DIFF
--- a/js/detect.js
+++ b/js/detect.js
@@ -2,7 +2,7 @@
 
   var VERSION_KEY = 'device';
   var FORCE_KEY = 'force';
-  var MQ_TOUCH = /\(touch-enabled: (.*?)\)/;
+  var MQ_TOUCH = /\(\s*?touch-enabled\s*:\s*(.*?)\s*\)/;
 
 
  /**


### PR DESCRIPTION
Currently, if a person provided extra spaces around the colon (that is valid), then the touch detection fails.

Take as an example the following media attribute:

```
'only screen and (touch-enabled : 0)'
```

The regexp `MQ_TOUCH` not will capture anything (because of space inserted before the colon) and then the mediaquerie will be relayed to Moderniz that, if the browser supports it, test it with `matchMedia`. Howerer, `touch-enabled` is not standardized, so the result will always be negative.
